### PR TITLE
Added flag to skip file errors during copy

### DIFF
--- a/cmd/skbn.go
+++ b/cmd/skbn.go
@@ -35,10 +35,11 @@ func NewRootCmd(args []string) *cobra.Command {
 }
 
 type cpCmd struct {
-	src        string
-	dst        string
-	parallel   int
-	bufferSize float64
+	src            string
+	dst            string
+	parallel       int
+	bufferSize     float64
+	skipErrorFiles bool
 
 	out io.Writer
 }
@@ -52,7 +53,7 @@ func NewCpCmd(out io.Writer) *cobra.Command {
 		Short: "Copy files or directories Kubernetes and Cloud storage",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := skbn.Copy(c.src, c.dst, c.parallel, c.bufferSize); err != nil {
+			if err := skbn.Copy(c.src, c.dst, c.parallel, c.bufferSize, c.skipErrorFiles); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/examples/code/example.go
+++ b/examples/code/example.go
@@ -14,7 +14,7 @@ func main() {
 	bufferSize := 1.0 // 1GB of in memory buffer size
 
 	start := time.Now()
-	if err := skbn.Copy(src, dst, parallel, bufferSize); err != nil {
+	if err := skbn.Copy(src, dst, parallel, bufferSize, false); err != nil {
 		log.Fatal(err)
 	}
 	elapsed := time.Since(start)


### PR DESCRIPTION
So in case an error occurs for one file, the file is skipped. The behavior is triggered via the method parameter skipErrorFiles.
If the parameter is set to false the behaviour is the same as before.

I have never coded go but this fix allowed me to skip files that got deleted during the backup run.
If there are better ways feel free to adjust or comment.


Signed-off-by: lhgloj1 <jannic.lollert@liebherr.com>